### PR TITLE
Wrong floating point numbers in German

### DIFF
--- a/Classes/Domain/Model/ChartDataSpreadsheet.php
+++ b/Classes/Domain/Model/ChartDataSpreadsheet.php
@@ -240,7 +240,7 @@ class ChartDataSpreadsheet extends ChartData
             $spreadsheetData,
             static function (&$item) {
                 if ($item instanceof \Hoogi91\Spreadsheets\Domain\ValueObject\CellDataValueObject) {
-                    $item = (float)$item->getRenderedValue();
+                    $item = (float)$item->getCalculatedValue();
                 } elseif ($item instanceof \Hoogi91\Spreadsheets\Domain\Model\CellValue) {// @phpstan-ignore-line
                     /** @deprecated since v1.1.0 and will be removed in v2.0 */
                     $item = (float)$item->getValue();// @phpstan-ignore-line


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

Relevant when you use hoogi91/spreadsheets with charts.
For some languages such as German, a decimal comma is used instead of a decimal point (16,9 instead of 16.9). If you typecast such a string to float, the decimal place gets stripped, resulting in 16.
I assume we do not specifically need the renderedValue in this case and can use the calculatedValue instead.
