### PR TITLE
feat: compatibility with Chart.js v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         include:
           # add experimental dev-master for PHP 7.4
           - php_version: '7.4'
-            typo3_version: 'dev-master'
+            typo3_version: 'dev-main'
             experimental: true
 
     steps:


### PR DESCRIPTION
Hi there,

we bundle Chart.js with our other JavaScript and would like to upgrade to Chart.js v3.

However since there was a breaking change, some adjustments are required to the chart configurations:
- horizontal bar chart: do not use "horizontalBar" as type as it was removed. set indexAxis setting to y instead.
- migrate chart options: rename xAxes/yAxes scale to "x" and "y" and move ticks settings up

The cleanest solution is obviously to upgrade the JS file configured in the Library class – dropping v2 support and creating a breaking change. For now I tried to apply them to still keep support to Chart.js v2 so we do not have a breaking change.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes/no
| Fixed tickets | #19   <!-- #-prefixed issue number(s), if any -->

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.
-->
