### PR TITLE
Change color-palette element style to block

### DIFF
--- a/Classes/Form/Element/ColorPaletteInputElement.php
+++ b/Classes/Form/Element/ColorPaletteInputElement.php
@@ -44,7 +44,7 @@ class ColorPaletteInputElement extends AbstractFormElement
     <div class="form-control-wrap">
         <div class="form-wizards-wrap">
             <input id="$inputIdentifier" type="hidden" name="$inputName" value="$inputValue"/>
-            <color-palette ref="$inputIdentifier" mode="preview" style="display:inline-block;height:32px">
+            <color-palette ref="$inputIdentifier" mode="preview" style="display:block;height:32px">
                 <span slot="empty">$emptyPaletteContent</span>
                 <span slot="newButtonIcon">
                     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">


### PR DESCRIPTION
This will allow the preview bar to be displayed

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #25

The inline-block does only show if there is content in it. Thus it will display the button but not the preview of the colors selected as there is no real content in it and therefore it has no width. By changing the display property to block, we achieve a full width button and a proper preview of the selected colors
