### PR TITLE
Change path to chartjs.js

### DIFF
--- a/Classes/DataProcessing/Charts/Library/ChartJs.php
+++ b/Classes/DataProcessing/Charts/Library/ChartJs.php
@@ -61,7 +61,7 @@ class ChartJs extends AbstractColoredLibrary implements LibraryFlexformInterface
         return array_filter(
             [
                 $cdnUrl => ['noConcat' => true],
-                'typo3conf/ext/charts/Resources/Public/JavaScript/chartjs.js' => ['compress' => true],
+                'EXT:charts/Resources/Public/JavaScript/chartjs.js' => ['compress' => true],
             ],
             static fn ($key) => empty($key) === false,
             ARRAY_FILTER_USE_KEY


### PR DESCRIPTION
The typo3conf folder doesn't exist in TYPO3 v12, so an 'EXT:...' path should be the most compatible way for all supported TYPO3 versions.

solves #368 which I think is a critical thing for TYPO3 12 (not usable otherwise)

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | should do (not installed in testing environment)
| Fixed tickets | #368
